### PR TITLE
feat: add news avatars, fix texts

### DIFF
--- a/src/components/sections/about.tsx
+++ b/src/components/sections/about.tsx
@@ -7,32 +7,47 @@ const speakers = [
 	{
 		name: 'Andressa',
 		imageUri: avatars.andressa,
-		classNames: 'left-0 z-[60]',
+		classNames: 'left-[-1rem] md:left-0 z-[60]',
 	},
 	{
 		name: 'Robson Júnior',
 		imageUri: avatars.robson,
-		classNames: 'left-[3.2rem] md:left-[3rem] z-[50]',
+		classNames: 'left-[2rem] md:left-[3rem] z-[59]',
 	},
 	{
 		name: 'Luiz Duarte',
 		imageUri: avatars.luiz,
-		classNames: 'left-[6.2rem] md:left-[6rem] z-[40]',
+		classNames: 'left-[4.4rem] md:left-[6rem] z-[58]',
 	},
 	{
 		name: 'Ed Pereira',
 		imageUri: avatars.ed,
-		classNames: 'left-[9.2rem] md:left-[9rem] z-[30]',
+		classNames: 'left-[7rem] md:left-[9rem] z-[57]',
 	},
 	{
 		name: 'Eduardo Garcia',
 		imageUri: avatars.eduardo,
-		classNames: 'left-[12.2rem] md:left-[12rem] z-[20]',
+		classNames: 'left-[9.3rem] md:left-[12rem] z-[56]',
 	},
 	{
 		name: 'Felipe Bastos',
 		imageUri: avatars.felipe,
-		classNames: 'left-[15.2rem] md:left-[15rem] z-[10]',
+		classNames: 'left-[12rem] md:left-[15rem] z-[55]',
+	},
+	{
+		name: 'Raryson Pereira',
+		imageUri: avatars.raryson,
+		classNames: 'left-[14.5rem] md:left-[18rem] z-[54]',
+	},
+	{
+		name: 'Alessandro Cauduro',
+		imageUri: avatars.alessandro,
+		classNames: 'left-[17rem] md:left-[21rem] z-[53]',
+	},
+	{
+		name: 'Rayana Garay',
+		imageUri: avatars.rayana,
+		classNames: 'left-[19rem] md:left-[24rem] z-[52]',
 	},
 ];
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,8 +45,8 @@ export const talks: TalkProps[] = [
 	},
 	{
 		position: 'middle',
-		title: 'Porque Acessibilidade',
-		description: 'na Web Pode Ser Difícil',
+		title: 'Por que acessibilidade',
+		description: 'na web pode ser difícil',
 		time: '09:55',
 		speaker: {
 			avatar: avatars.ed,
@@ -58,13 +58,13 @@ export const talks: TalkProps[] = [
 	},
 	{
 		position: 'middle',
-		title: 'Coffee Break',
+		title: 'Coffee break',
 		time: '10:25',
 	},
 	{
 		position: 'middle',
-		title: 'Deploying AI Agents on the Edge',
-		description: 'Real-World Applications',
+		title: 'Deploying AI Agents on the edge',
+		description: 'real-world applications',
 		speaker: {
 			avatar: avatars.alessandro,
 			name: 'Alessandro Cauduro',
@@ -76,8 +76,8 @@ export const talks: TalkProps[] = [
 	},
 	{
 		position: 'middle',
-		title: 'Jornada na Programação',
-		description: 'Desafios e Crescimento',
+		title: 'Jornada na programação',
+		description: 'desafios e crescimento',
 		time: '11:30',
 		speaker: {
 			avatar: avatars.andressa,
@@ -107,15 +107,15 @@ export const talks: TalkProps[] = [
 	},
 	{
 		position: 'middle',
-		title: 'Integrando LLMs e Machine',
-		description: 'em Processos de Dados',
+		title: 'Integrando LLMs e machine learning',
+		description: 'em processos de dados',
 		time: '14:25',
 		speaker: {
 			avatar: avatars.eduardo,
 			name: 'Eduardo Garcia',
 			company: 'na SoftDesign',
 			linkedin: 'https://www.linkedin.com/in/eduardomellogarcia/',
-			role: 'Desenvolvedores Full Stack',
+			role: 'Software Engineers Full Stack',
 			collaborator: {
 				avatar: avatars.felipe,
 				name: 'Felipe Bastos',
@@ -125,13 +125,13 @@ export const talks: TalkProps[] = [
 	},
 	{
 		position: 'middle',
-		title: 'Coffee Break',
+		title: 'Coffee break',
 		time: '15:00',
 	},
 	{
 		position: 'middle',
-		title: 'Management Application',
-		description: 'com Azion Edge Computing',
+		title: 'Management application',
+		description: 'com Azion edge computing',
 		time: '15:30',
 		speaker: {
 			avatar: avatars.robson,
@@ -143,8 +143,8 @@ export const talks: TalkProps[] = [
 	},
 	{
 		position: 'middle',
-		title: 'Integrando Devs no Discovery',
-		description: 'Uma Abordagem Colaborativa',
+		title: 'Integrando devs no discovery',
+		description: 'uma abordagem colaborativa',
 		speaker: {
 			avatar: avatars.rayana,
 			name: 'Rayana Garay',


### PR DESCRIPTION
Foi criado nesse PR:

- Adicionado a lista dos avatares que estavam faltando;
- Ajustado alguns textos do site;
- Alterado o left no mobile dos avatares;

Prints da lista de palestrantes no responsivo. Testado em um iphone 11:
![WhatsApp Image 2024-12-09 at 16 49 04](https://github.com/user-attachments/assets/514f66eb-5126-498b-bc42-6a4e3b61ad16)

Prints no modo desktop:
![image](https://github.com/user-attachments/assets/cc241eb6-5d21-41ae-86c9-397afe8ab279)
